### PR TITLE
Set keyboard frame to below the window when resigning first responder

### DIFF
--- a/Echo/controllers/input_accessory_controller.swift
+++ b/Echo/controllers/input_accessory_controller.swift
@@ -94,11 +94,15 @@ public class InputAccessoryController: NSObject {
         }
 
         if keyboardNotification.type == .willHide || keyboardNotification.type == .willShow || keyboardNotification.type == .didHide {
-
-          let textViewInputAccesoryHeight = self.textView.inputAccessoryView?.bounds.height ?? 0
-          let origin = CGPoint(
-            x: keyboardNotification.end.minX,
-            y: keyboardNotification.end.minY + textViewInputAccesoryHeight - self.accessoryView.bounds.height)
+          let height = self.scrollView.window!.frame.height
+          let origin: CGPoint
+          if keyboardNotification.type == .willShow {
+            origin = CGPoint(
+              x: keyboardNotification.end.minX,
+              y: height - keyboardNotification.end.height - self.accessoryView.bounds.height)
+          } else {
+            origin = CGPoint(x: 0, y: self.scrollView.window!.frame.height)
+          }
 
           self.delegate?.updateAccessoryView(CGRect(origin: origin, size: self.accessoryView.bounds.size),
             adjustContentOffset: true,


### PR DESCRIPTION
We want the accessory view at the bottom when the keyboard is undocked.
When undocking apple fires 'correctly' the will hide keyboard
notification, but the frame is where the keyboard will be, when
undocked. We therefor need to intersect it in these cases and return a
rect below the window.
